### PR TITLE
feat: add delete training, stats page, search filter, and network guard

### DIFF
--- a/dtrainings-ui/src/App.tsx
+++ b/dtrainings-ui/src/App.tsx
@@ -7,6 +7,7 @@ import { Link, Route, Routes } from "react-router-dom";
 import Home from "./components/Home/Home";
 import GlobalStyle from "./GlobalStyle";
 import TrainingsManager from "./components/TrainingsManager/TrainingsManager";
+import Stats from "./components/Stats/Stats";
 
 function App() {
     return (
@@ -18,6 +19,7 @@ function App() {
                     <Routes>
                         <Route path="/" element={<Home />} />
                         <Route path="/trainings-manager" element={<TrainingsManager />} />
+                        <Route path="/stats" element={<Stats />} />
                     </Routes>
                 </RainbowKitProvider>
             </QueryClientProvider>

--- a/dtrainings-ui/src/components/Home/Home.tsx
+++ b/dtrainings-ui/src/components/Home/Home.tsx
@@ -48,8 +48,10 @@ const Home = () => {
                         </p>
                     </div>
 
-                    <div className="feature-card feature-card--disabled">
-                        <span className="feature-card__badge">Soon</span>
+                    <div
+                        className="feature-card feature-card--active"
+                        onClick={() => navigate('/stats')}
+                    >
                         <div className="feature-card__icon">&#x1F4CA;</div>
                         <h3 className="feature-card__title">Your Stats</h3>
                         <p className="feature-card__description">

--- a/dtrainings-ui/src/components/Navbar/Navbar.tsx
+++ b/dtrainings-ui/src/components/Navbar/Navbar.tsx
@@ -30,6 +30,9 @@ const Navbar = () => {
                 <li className={`navbar__nav-item ${isActive('/trainings-manager') ? 'navbar__nav-item--active' : ''}`}>
                     <Link to="/trainings-manager" onClick={() => setMenuOpen(false)}>Trainings</Link>
                 </li>
+                <li className={`navbar__nav-item ${isActive('/stats') ? 'navbar__nav-item--active' : ''}`}>
+                    <Link to="/stats" onClick={() => setMenuOpen(false)}>Stats</Link>
+                </li>
             </ul>
 
             <div className={`navbar__actions ${menuOpen ? 'navbar__actions--open' : ''}`}>

--- a/dtrainings-ui/src/components/Stats/Stats.scss
+++ b/dtrainings-ui/src/components/Stats/Stats.scss
@@ -1,0 +1,151 @@
+@use '../../styles/variables' as *;
+@use '../../styles/mixins' as *;
+
+.stats-page {
+  min-height: 100vh;
+  background: $bg-base;
+}
+
+.stats-loading,
+.stats-error {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  color: $text-secondary;
+  gap: $space-md;
+}
+
+.stats-spinner {
+  width: 40px;
+  height: 40px;
+  border: 3px solid $border-color;
+  border-top-color: $accent;
+  border-radius: 50%;
+  animation: statsSpin 0.8s linear infinite;
+}
+
+@keyframes statsSpin {
+  to { transform: rotate(360deg); }
+}
+
+.stats-error {
+  color: $danger;
+
+  &__message {
+    color: $text-secondary;
+    font-size: $font-size-sm;
+  }
+}
+
+.stats-container {
+  @include page-container;
+  color: $text-primary;
+}
+
+.stats-title {
+  font-size: $font-size-xl;
+  font-weight: 600;
+  margin-bottom: $space-2xl;
+}
+
+.stats-empty {
+  text-align: center;
+  padding: $space-3xl $space-xl;
+  color: $text-secondary;
+
+  &__icon {
+    font-size: 3rem;
+    margin-bottom: $space-md;
+    opacity: 0.5;
+  }
+
+  h2 {
+    font-size: $font-size-xl;
+    color: $text-primary;
+    margin-bottom: $space-sm;
+    font-weight: 600;
+  }
+
+  p {
+    color: $text-muted;
+  }
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: $space-lg;
+  margin-bottom: $space-2xl;
+
+  @include respond-to(lg) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  @include respond-to(sm) {
+    grid-template-columns: 1fr;
+  }
+}
+
+.stat-card {
+  @include card;
+  display: flex;
+  flex-direction: column;
+  gap: $space-xs;
+
+  &__label {
+    font-size: $font-size-xs;
+    color: $text-muted;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 500;
+  }
+
+  &__value {
+    font-size: $font-size-2xl;
+    font-weight: 700;
+    color: $accent;
+  }
+
+  &__sub {
+    font-size: $font-size-sm;
+    color: $text-secondary;
+  }
+}
+
+.stats-recent {
+  &__title {
+    font-size: $font-size-lg;
+    font-weight: 600;
+    margin-bottom: $space-lg;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: $space-sm;
+  }
+
+  &__item {
+    @include card;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: $space-md $space-lg;
+  }
+
+  &__name {
+    font-weight: 500;
+    color: $text-primary;
+  }
+
+  &__duration {
+    font-size: $font-size-sm;
+    color: $accent;
+    background: rgba(79, 143, 255, 0.1);
+    padding: $space-xs $space-sm;
+    border-radius: $radius-pill;
+    font-weight: 500;
+  }
+}

--- a/dtrainings-ui/src/components/Stats/Stats.scss
+++ b/dtrainings-ui/src/components/Stats/Stats.scss
@@ -135,6 +135,17 @@
     padding: $space-md $space-lg;
   }
 
+  &__meta {
+    display: flex;
+    align-items: center;
+    gap: $space-md;
+  }
+
+  &__date {
+    font-size: $font-size-xs;
+    color: $text-muted;
+  }
+
   &__name {
     font-weight: 500;
     color: $text-primary;

--- a/dtrainings-ui/src/components/Stats/Stats.tsx
+++ b/dtrainings-ui/src/components/Stats/Stats.tsx
@@ -21,6 +21,10 @@ const Stats = () => {
         return longest;
     }, null);
 
+    const recentTrainings = [...trainings]
+        .sort((a, b) => Number(b.createdAt) - Number(a.createdAt))
+        .slice(0, 5);
+
     if (isLoading) return (
         <div className="stats-page">
             <Navbar />
@@ -80,12 +84,19 @@ const Stats = () => {
                             <div className="stats-recent">
                                 <h2 className="stats-recent__title">Recent Trainings</h2>
                                 <div className="stats-recent__list">
-                                    {trainings.slice(-5).reverse().map((training, index) => (
+                                    {recentTrainings.map((training, index) => (
                                         <div key={index} className="stats-recent__item">
                                             <span className="stats-recent__name">{training.name}</span>
-                                            <span className="stats-recent__duration">
-                                                {training.durationInMinutes.toString()} min
-                                            </span>
+                                            <div className="stats-recent__meta">
+                                                {training.createdAt > BigInt(0) && (
+                                                    <span className="stats-recent__date">
+                                                        {new Date(Number(training.createdAt) * 1000).toLocaleDateString()}
+                                                    </span>
+                                                )}
+                                                <span className="stats-recent__duration">
+                                                    {training.durationInMinutes.toString()} min
+                                                </span>
+                                            </div>
                                         </div>
                                     ))}
                                 </div>

--- a/dtrainings-ui/src/components/Stats/Stats.tsx
+++ b/dtrainings-ui/src/components/Stats/Stats.tsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import './Stats.scss';
+import { useGetTrainingsForUser } from "../../hooks/queries/useGetTrainings";
+import { useAccount } from "wagmi";
+import Navbar from "../Navbar/Navbar";
+import NetworkGuard from "../common/NetworkGuard";
+
+const Stats = () => {
+    const { address } = useAccount();
+    const { data: trainings = [], isLoading, isError, error } = useGetTrainingsForUser([address]);
+
+    const totalTrainings = trainings.length;
+    const totalMinutes = trainings.reduce((sum, t) => sum + Number(t.durationInMinutes), 0);
+    const averageMinutes = totalTrainings > 0 ? Math.round(totalMinutes / totalTrainings) : 0;
+
+    const longestTraining = trainings.reduce<{ name: string; duration: number } | null>((longest, t) => {
+        const dur = Number(t.durationInMinutes);
+        if (!longest || dur > longest.duration) {
+            return { name: t.name, duration: dur };
+        }
+        return longest;
+    }, null);
+
+    if (isLoading) return (
+        <div className="stats-page">
+            <Navbar />
+            <div className="stats-loading">
+                <div className="stats-spinner" />
+                <p>Loading stats...</p>
+            </div>
+        </div>
+    );
+
+    if (isError) return (
+        <div className="stats-page">
+            <Navbar />
+            <div className="stats-error">
+                <p>Failed to load stats</p>
+                <p className="stats-error__message">{error.message}</p>
+            </div>
+        </div>
+    );
+
+    return (
+        <div className="stats-page">
+            <Navbar />
+
+            <NetworkGuard>
+                <div className="stats-container">
+                    <h1 className="stats-title">Your Stats</h1>
+
+                    {totalTrainings === 0 ? (
+                        <div className="stats-empty">
+                            <div className="stats-empty__icon">&#x1F4CA;</div>
+                            <h2>No data yet</h2>
+                            <p>Start logging trainings to see your statistics here.</p>
+                        </div>
+                    ) : (
+                        <>
+                            <div className="stats-grid">
+                                <div className="stat-card">
+                                    <span className="stat-card__label">Total Trainings</span>
+                                    <span className="stat-card__value">{totalTrainings}</span>
+                                </div>
+                                <div className="stat-card">
+                                    <span className="stat-card__label">Total Time</span>
+                                    <span className="stat-card__value">{totalMinutes} min</span>
+                                </div>
+                                <div className="stat-card">
+                                    <span className="stat-card__label">Average Duration</span>
+                                    <span className="stat-card__value">{averageMinutes} min</span>
+                                </div>
+                                <div className="stat-card">
+                                    <span className="stat-card__label">Longest Training</span>
+                                    <span className="stat-card__value">{longestTraining?.duration} min</span>
+                                    <span className="stat-card__sub">{longestTraining?.name}</span>
+                                </div>
+                            </div>
+
+                            <div className="stats-recent">
+                                <h2 className="stats-recent__title">Recent Trainings</h2>
+                                <div className="stats-recent__list">
+                                    {trainings.slice(-5).reverse().map((training, index) => (
+                                        <div key={index} className="stats-recent__item">
+                                            <span className="stats-recent__name">{training.name}</span>
+                                            <span className="stats-recent__duration">
+                                                {training.durationInMinutes.toString()} min
+                                            </span>
+                                        </div>
+                                    ))}
+                                </div>
+                            </div>
+                        </>
+                    )}
+                </div>
+            </NetworkGuard>
+        </div>
+    );
+};
+
+export default Stats;

--- a/dtrainings-ui/src/components/TrainingsManager/CreateTrainingDetailsModal.scss
+++ b/dtrainings-ui/src/components/TrainingsManager/CreateTrainingDetailsModal.scss
@@ -60,6 +60,11 @@
     @include form-input;
   }
 
+  &__input:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
   &__textarea {
     height: 90px;
     resize: vertical;

--- a/dtrainings-ui/src/components/TrainingsManager/CreateTrainingDetailsModal.tsx
+++ b/dtrainings-ui/src/components/TrainingsManager/CreateTrainingDetailsModal.tsx
@@ -5,20 +5,22 @@ import "./CreateTrainingDetailsModal.scss";
 interface TrainingDetailsModalProps {
     training: TrainingInfo | null;
     isOpen: boolean;
+    mode: "create" | "edit";
     onClose: () => void;
     onConfirm: (updatedTraining: TrainingInfo) => void;
 }
 
-const CreateTrainingDetailsModal: React.FC<TrainingDetailsModalProps> = ({ training, isOpen, onClose, onConfirm }) => {
+const CreateTrainingDetailsModal: React.FC<TrainingDetailsModalProps> = ({ training, isOpen, mode, onClose, onConfirm }) => {
     const [formData, setFormData] = useState<TrainingInfo>({
         name: "",
         description: "",
-        durationInMinutes: BigInt(0)
+        durationInMinutes: BigInt(0),
+        createdAt: BigInt(0)
     });
 
     useEffect(() => {
         if (isOpen) {
-            setFormData(training || { name: "", description: "", durationInMinutes: BigInt(0) });
+            setFormData(training || { name: "", description: "", durationInMinutes: BigInt(0), createdAt: BigInt(0) });
         }
     }, [isOpen, training]);
 
@@ -49,11 +51,13 @@ const CreateTrainingDetailsModal: React.FC<TrainingDetailsModalProps> = ({ train
         }
     };
 
+    const isEdit = mode === "edit";
+
     return (
         <div className="training-modal__overlay" onClick={handleOverlayClick}>
             <div className="training-modal__content">
                 <button className="training-modal__close" onClick={onClose}>&times;</button>
-                <h2 className="training-modal__title">Create Training</h2>
+                <h2 className="training-modal__title">{isEdit ? "Edit Training" : "Create Training"}</h2>
 
                 <div className="training-modal__field">
                     <label htmlFor="training-name" className="training-modal__label">Title</label>
@@ -65,6 +69,7 @@ const CreateTrainingDetailsModal: React.FC<TrainingDetailsModalProps> = ({ train
                         onChange={handleChange}
                         placeholder="Enter training title"
                         className="training-modal__input"
+                        disabled={isEdit}
                     />
                 </div>
 
@@ -95,7 +100,7 @@ const CreateTrainingDetailsModal: React.FC<TrainingDetailsModalProps> = ({ train
 
                 <div className="training-modal__actions">
                     <button onClick={handleConfirm} disabled={!isValid} className="training-modal__confirm">
-                        Confirm
+                        {isEdit ? "Save Changes" : "Create"}
                     </button>
                     <button onClick={onClose} className="training-modal__cancel">Cancel</button>
                 </div>

--- a/dtrainings-ui/src/components/TrainingsManager/TrainingsManager.scss
+++ b/dtrainings-ui/src/components/TrainingsManager/TrainingsManager.scss
@@ -48,14 +48,41 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: $space-2xl;
+    gap: $space-md;
 
     h1 {
       font-size: $font-size-xl;
       font-weight: 600;
+      white-space: nowrap;
+    }
+
+    &__actions {
+      display: flex;
+      align-items: center;
+      gap: $space-sm;
     }
 
     .create-training-btn {
       @include button-primary;
+      white-space: nowrap;
+    }
+
+    @include respond-to(sm) {
+      flex-direction: column;
+      align-items: stretch;
+
+      &__actions {
+        flex-direction: column;
+      }
+    }
+  }
+
+  .trainings-search {
+    @include form-input;
+    width: 220px;
+
+    @include respond-to(sm) {
+      width: 100%;
     }
   }
 

--- a/dtrainings-ui/src/components/TrainingsManager/TrainingsManager.scss
+++ b/dtrainings-ui/src/components/TrainingsManager/TrainingsManager.scss
@@ -158,6 +158,13 @@
       font-size: $font-size-sm;
       line-height: 1.5;
       flex: 1;
+      margin-bottom: $space-sm;
+    }
+
+    &__date {
+      display: block;
+      font-size: $font-size-xs;
+      color: $text-muted;
       margin-bottom: $space-md;
     }
 
@@ -167,6 +174,11 @@
       display: flex;
       justify-content: space-between;
       align-items: center;
+    }
+
+    &__actions {
+      display: flex;
+      gap: $space-sm;
     }
 
     .status-badge {
@@ -186,6 +198,26 @@
         height: 6px;
         background: $success;
         border-radius: 50%;
+      }
+    }
+
+    .edit-btn {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      background: transparent;
+      color: $accent;
+      border: 1px solid $accent;
+      border-radius: $radius-pill;
+      padding: $space-xs $space-md;
+      font-size: $font-size-xs;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background $transition-fast, color $transition-fast;
+
+      &:hover {
+        background: $accent;
+        color: $bg-base;
       }
     }
 

--- a/dtrainings-ui/src/components/TrainingsManager/TrainingsManager.tsx
+++ b/dtrainings-ui/src/components/TrainingsManager/TrainingsManager.tsx
@@ -1,16 +1,24 @@
 import React, { useState } from 'react';
 import './TrainingsManager.scss';
 import useAddTraining from "../../hooks/mutations/useAddTraining";
+import useDeleteTraining from "../../hooks/mutations/useDeleteTraining";
 import { useGetTrainingsForUser } from "../../hooks/queries/useGetTrainings";
 import { useAccount } from "wagmi";
+import { useQueryClient } from "@tanstack/react-query";
 import Navbar from "../Navbar/Navbar";
 import CreateTrainingDetailsModal from "./CreateTrainingDetailsModal";
+import ConfirmDialog from "../common/ConfirmDialog";
+import NetworkGuard from "../common/NetworkGuard";
 import { TrainingInfo } from "interfaces/trainings";
 import { toast, ToastContainer } from "react-toastify";
 
 const TrainingsManager = () => {
     const [selectedTraining, setSelectedTraining] = useState<TrainingInfo | null>(null);
     const [isModalOpen, setIsModalOpen] = useState(false);
+    const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
+    const [searchQuery, setSearchQuery] = useState('');
+
+    const queryClient = useQueryClient();
 
     const closeModal = () => {
         setIsModalOpen(false);
@@ -41,11 +49,32 @@ const TrainingsManager = () => {
 
     const addTrainingMutation = useAddTraining({ onError, onSuccess });
 
+    const deleteTrainingMutation = useDeleteTraining({
+        onError: () => {
+            toast("Error deleting training", { type: "error" });
+        },
+        onSuccess: () => {
+            toast("Training deleted. It may take a while to process on the blockchain.", { type: "success" });
+            queryClient.invalidateQueries({ queryKey: ['getTrainings'] });
+        },
+    });
+
     const { data: trainings = [], isLoading, isError, error } = useGetTrainingsForUser([address]);
 
-    const handleDelete = (id: number) => {
-        console.log("deleted");
+    const handleDelete = (name: string) => {
+        setDeleteTarget(name);
     };
+
+    const confirmDelete = async () => {
+        if (deleteTarget) {
+            await deleteTrainingMutation.mutateAsync(deleteTarget);
+            setDeleteTarget(null);
+        }
+    };
+
+    const filteredTrainings = trainings.filter(t =>
+        t.name.toLowerCase().includes(searchQuery.toLowerCase())
+    );
 
     if (isLoading) return (
         <div className="trainings-page">
@@ -72,47 +101,66 @@ const TrainingsManager = () => {
             <Navbar />
             <ToastContainer />
 
-            <div className="trainings-container">
-                <div className="trainings-header">
-                    <h1>Your Trainings</h1>
-                    <button onClick={openCreateModal} className="create-training-btn">
-                        + Create Training
-                    </button>
-                </div>
+            <NetworkGuard>
+                <div className="trainings-container">
+                    <div className="trainings-header">
+                        <h1>Your Trainings</h1>
+                        <div className="trainings-header__actions">
+                            <input
+                                type="text"
+                                className="trainings-search"
+                                placeholder="Search trainings..."
+                                value={searchQuery}
+                                onChange={(e) => setSearchQuery(e.target.value)}
+                            />
+                            <button onClick={openCreateModal} className="create-training-btn">
+                                + Create Training
+                            </button>
+                        </div>
+                    </div>
 
-                {trainings.length === 0 ? (
-                    <div className="no-trainings">
-                        <div className="no-trainings__icon">&#x1F3CB;</div>
-                        <h2>No trainings yet</h2>
-                        <p>Start tracking your workouts by creating your first training session.</p>
-                        <button onClick={openCreateModal} className="create-training-btn">
-                            + Create Training
-                        </button>
-                    </div>
-                ) : (
-                    <div className="trainings-list">
-                        {trainings.map((training, index) => (
-                            <div key={index} className="training-card">
-                                <div className="training-card__header">
-                                    <h3 className="training-card__title">{training.name}</h3>
-                                    <span className="training-card__duration">
-                                        {training.durationInMinutes.toString()} min
-                                    </span>
+                    {trainings.length === 0 ? (
+                        <div className="no-trainings">
+                            <div className="no-trainings__icon">&#x1F3CB;</div>
+                            <h2>No trainings yet</h2>
+                            <p>Start tracking your workouts by creating your first training session.</p>
+                            <button onClick={openCreateModal} className="create-training-btn">
+                                + Create Training
+                            </button>
+                        </div>
+                    ) : (
+                        <div className="trainings-list">
+                            {filteredTrainings.map((training, index) => (
+                                <div key={index} className="training-card">
+                                    <div className="training-card__header">
+                                        <h3 className="training-card__title">{training.name}</h3>
+                                        <span className="training-card__duration">
+                                            {training.durationInMinutes.toString()} min
+                                        </span>
+                                    </div>
+                                    <p className="training-card__description">{training.description}</p>
+                                    <div className="training-card__footer">
+                                        <span className="status-badge">Done</span>
+                                        <button
+                                            onClick={() => handleDelete(training.name)}
+                                            className="delete-btn">
+                                            Delete
+                                        </button>
+                                    </div>
                                 </div>
-                                <p className="training-card__description">{training.description}</p>
-                                <div className="training-card__footer">
-                                    <span className="status-badge">Done</span>
-                                    <button
-                                        onClick={() => handleDelete(index)}
-                                        className="delete-btn">
-                                        Delete
-                                    </button>
-                                </div>
-                            </div>
-                        ))}
-                    </div>
-                )}
-            </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            </NetworkGuard>
+
+            <ConfirmDialog
+                isOpen={deleteTarget !== null}
+                title="Delete Training"
+                message={`Are you sure you want to delete "${deleteTarget}"? This action cannot be undone.`}
+                onConfirm={confirmDelete}
+                onCancel={() => setDeleteTarget(null)}
+            />
 
             <CreateTrainingDetailsModal training={selectedTraining} isOpen={isModalOpen} onClose={closeModal} onConfirm={confirmTraining} />
         </div>

--- a/dtrainings-ui/src/components/common/ConfirmDialog.scss
+++ b/dtrainings-ui/src/components/common/ConfirmDialog.scss
@@ -1,0 +1,82 @@
+@use '../../styles/variables' as *;
+@use '../../styles/mixins' as *;
+
+.confirm-dialog {
+  &__overlay {
+    @include modal-overlay;
+  }
+
+  &__content {
+    background: $bg-modal;
+    color: $text-primary;
+    padding: $space-2xl;
+    border-radius: $radius-lg;
+    width: 90%;
+    max-width: 380px;
+    border: 1px solid $border-color;
+    box-shadow: $shadow-lg;
+    animation: confirmSlideIn $transition-base;
+  }
+
+  &__title {
+    font-size: $font-size-xl;
+    font-weight: 600;
+    margin-bottom: $space-sm;
+  }
+
+  &__message {
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: 1.5;
+    margin-bottom: $space-xl;
+  }
+
+  &__actions {
+    display: flex;
+    gap: $space-sm;
+  }
+
+  &__confirm {
+    @include button-danger;
+    flex: 1;
+    padding: $space-sm $space-lg;
+    background: $danger;
+    color: #fff;
+    border: 1px solid $danger;
+
+    &:hover {
+      background: $danger-hover;
+    }
+  }
+
+  &__cancel {
+    flex: 1;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    color: $text-secondary;
+    border: 1px solid $border-color;
+    border-radius: $radius-pill;
+    padding: $space-sm $space-lg;
+    font-size: $font-size-sm;
+    cursor: pointer;
+    transition: border-color $transition-fast, color $transition-fast;
+
+    &:hover {
+      border-color: $text-muted;
+      color: $text-primary;
+    }
+  }
+}
+
+@keyframes confirmSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(-10px) scale(0.97);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}

--- a/dtrainings-ui/src/components/common/ConfirmDialog.tsx
+++ b/dtrainings-ui/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import './ConfirmDialog.scss';
+
+interface ConfirmDialogProps {
+    isOpen: boolean;
+    title: string;
+    message: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+}
+
+const ConfirmDialog: React.FC<ConfirmDialogProps> = ({ isOpen, title, message, onConfirm, onCancel }) => {
+    if (!isOpen) return null;
+
+    const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        if (e.target === e.currentTarget) {
+            onCancel();
+        }
+    };
+
+    return (
+        <div className="confirm-dialog__overlay" onClick={handleOverlayClick}>
+            <div className="confirm-dialog__content">
+                <h3 className="confirm-dialog__title">{title}</h3>
+                <p className="confirm-dialog__message">{message}</p>
+                <div className="confirm-dialog__actions">
+                    <button onClick={onConfirm} className="confirm-dialog__confirm">
+                        Confirm
+                    </button>
+                    <button onClick={onCancel} className="confirm-dialog__cancel">
+                        Cancel
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ConfirmDialog;

--- a/dtrainings-ui/src/components/common/NetworkGuard.scss
+++ b/dtrainings-ui/src/components/common/NetworkGuard.scss
@@ -1,0 +1,49 @@
+@use '../../styles/variables' as *;
+@use '../../styles/mixins' as *;
+
+.network-guard {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+  padding: $space-xl;
+
+  &__card {
+    @include card;
+    text-align: center;
+    padding: $space-2xl $space-xl;
+    max-width: 420px;
+
+    &:hover {
+      transform: none;
+    }
+  }
+
+  &__icon {
+    font-size: 3rem;
+    margin-bottom: $space-md;
+  }
+
+  &__title {
+    font-size: $font-size-xl;
+    font-weight: 600;
+    color: $warning;
+    margin-bottom: $space-sm;
+  }
+
+  &__message {
+    color: $text-secondary;
+    font-size: $font-size-sm;
+    line-height: 1.5;
+    margin-bottom: $space-xl;
+
+    strong {
+      color: $text-primary;
+    }
+  }
+
+  &__button {
+    @include button-primary;
+    width: 100%;
+  }
+}

--- a/dtrainings-ui/src/components/common/NetworkGuard.tsx
+++ b/dtrainings-ui/src/components/common/NetworkGuard.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { useAccount, useSwitchChain } from 'wagmi';
+import networkConfig from '../../constants';
+import './NetworkGuard.scss';
+
+interface NetworkGuardProps {
+    children: React.ReactNode;
+}
+
+const NetworkGuard: React.FC<NetworkGuardProps> = ({ children }) => {
+    const { chain } = useAccount();
+    const { switchChain } = useSwitchChain();
+
+    if (chain && chain.id !== networkConfig.id) {
+        return (
+            <div className="network-guard">
+                <div className="network-guard__card">
+                    <div className="network-guard__icon">&#x26A0;</div>
+                    <h2 className="network-guard__title">Wrong Network</h2>
+                    <p className="network-guard__message">
+                        Please switch to <strong>{networkConfig.name}</strong> to use this application.
+                    </p>
+                    <button
+                        className="network-guard__button"
+                        onClick={() => switchChain({ chainId: networkConfig.id })}
+                    >
+                        Switch to {networkConfig.name}
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    return <>{children}</>;
+};
+
+export default NetworkGuard;

--- a/dtrainings-ui/src/constants/configs.ts
+++ b/dtrainings-ui/src/constants/configs.ts
@@ -2,13 +2,16 @@ import { NetworkConfig } from "./types";
 
 export const localNetworkConfig: NetworkConfig = {
     id: 1337,
+    name: 'Localhost',
 }
 
 export const mainnetNetworkConfig: NetworkConfig = {
     id: 1,
+    name: 'Ethereum Mainnet',
 }
 
 export const sepoliaNetworkConfig: NetworkConfig = {
     id: 11155111,
+    name: 'Sepolia',
 }
 

--- a/dtrainings-ui/src/constants/types.ts
+++ b/dtrainings-ui/src/constants/types.ts
@@ -3,4 +3,5 @@ import { mainnet, sepolia, localhost } from 'wagmi/chains';
 
 export type NetworkConfig = {
     id: number;
+    name: string;
 };

--- a/dtrainings-ui/src/hooks/contracts/abi/TrainingsManager.json
+++ b/dtrainings-ui/src/hooks/contracts/abi/TrainingsManager.json
@@ -32,6 +32,19 @@
     },
     {
       "type": "function",
+      "name": "deleteTraining",
+      "inputs": [
+        {
+          "name": "name",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
       "name": "getTrainings",
       "inputs": [
         {
@@ -68,37 +81,10 @@
     },
     {
       "type": "function",
-      "name": "trainings",
-      "inputs": [
-        {
-          "name": "",
-          "type": "address",
-          "internalType": "address"
-        },
-        {
-          "name": "",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "outputs": [
-        {
-          "name": "name",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        },
-        {
-          "name": "description",
-          "type": "bytes32",
-          "internalType": "bytes32"
-        },
-        {
-          "name": "durationInMinutes",
-          "type": "uint256",
-          "internalType": "uint256"
-        }
-      ],
-      "stateMutability": "view"
+      "name": "initialize",
+      "inputs": [],
+      "outputs": [],
+      "stateMutability": "nonpayable"
     },
     {
       "type": "event",
@@ -118,197 +104,25 @@
         }
       ],
       "anonymous": false
-    }
-  ],
-  "bytecode": {
-    "object": "0x6080604052348015600e575f80fd5b506102fd8061001c5f395ff3fe608060405234801561000f575f80fd5b506004361061003f575f3560e01c80635898d0181461004357806377f6c91e14610076578063f1e823e214610096575b5f80fd5b610056610051366004610211565b6100ab565b604080519384526020840192909252908201526060015b60405180910390f35b610089610084366004610239565b6100e8565b60405161006d9190610259565b6100a96100a43660046102b1565b610175565b005b5f602052815f5260405f2081815481106100c3575f80fd5b5f91825260209091206003909102018054600182015460029092015490935090915083565b6001600160a01b0381165f90815260208181526040808320805482518185028101850190935280835260609492939192909184015b8282101561016a578382905f5260205f2090600302016040518060600160405290815f8201548152602001600182015481526020016002820154815250508152602001906001019061011d565b505050509050919050565b335f818152602081815260408220805460018101825590835291208391600302016101b782828135815560208201356001820155604082013560028201555050565b505060408051833581523360208201527f1e80e483f7da92147f26155e4c7fe167b8f08b8f9839de4b5fe9bab652f68c13910160405180910390a15050565b80356001600160a01b038116811461020c575f80fd5b919050565b5f8060408385031215610222575f80fd5b61022b836101f6565b946020939093013593505050565b5f60208284031215610249575f80fd5b610252826101f6565b9392505050565b602080825282518282018190525f919060409081850190868401855b828110156102a45781518051855286810151878601528501518585015260609093019290850190600101610275565b5091979650505050505050565b5f606082840312156102c1575f80fd5b5091905056fea2646970667358221220f805082d42456625767a5fd914c09d849d2b2ef6750d42934c5b614082412f7864736f6c63430008190033",
-    "sourceMap": "125:477:16:-:0;;;;;;;;;;;;;;;;;;;",
-    "linkReferences": {}
-  },
-  "deployedBytecode": {
-    "object": "0x608060405234801561000f575f80fd5b506004361061003f575f3560e01c80635898d0181461004357806377f6c91e14610076578063f1e823e214610096575b5f80fd5b610056610051366004610211565b6100ab565b604080519384526020840192909252908201526060015b60405180910390f35b610089610084366004610239565b6100e8565b60405161006d9190610259565b6100a96100a43660046102b1565b610175565b005b5f602052815f5260405f2081815481106100c3575f80fd5b5f91825260209091206003909102018054600182015460029092015490935090915083565b6001600160a01b0381165f90815260208181526040808320805482518185028101850190935280835260609492939192909184015b8282101561016a578382905f5260205f2090600302016040518060600160405290815f8201548152602001600182015481526020016002820154815250508152602001906001019061011d565b505050509050919050565b335f818152602081815260408220805460018101825590835291208391600302016101b782828135815560208201356001820155604082013560028201555050565b505060408051833581523360208201527f1e80e483f7da92147f26155e4c7fe167b8f08b8f9839de4b5fe9bab652f68c13910160405180910390a15050565b80356001600160a01b038116811461020c575f80fd5b919050565b5f8060408385031215610222575f80fd5b61022b836101f6565b946020939093013593505050565b5f60208284031215610249575f80fd5b610252826101f6565b9392505050565b602080825282518282018190525f919060409081850190868401855b828110156102a45781518051855286810151878601528501518585015260609093019290850190600101610275565b5091979650505050505050565b5f606082840312156102c1575f80fd5b5091905056fea2646970667358221220f805082d42456625767a5fd914c09d849d2b2ef6750d42934c5b614082412f7864736f6c63430008190033",
-    "sourceMap": "125:477:16:-:0;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;295:51:15;;;;;;:::i;:::-;;:::i;:::-;;;;653:25:17;;;709:2;694:18;;687:34;;;;737:18;;;730:34;641:2;626:18;295:51:15;;;;;;;;473:127:16;;;;;;:::i;:::-;;:::i;:::-;;;;;;;:::i;237:230::-;;;;;;:::i;:::-;;:::i;:::-;;295:51:15;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;-1:-1:-1;295:51:15;;-1:-1:-1;295:51:15;:::o;473:127:16:-;-1:-1:-1;;;;;575:18:16;;:9;:18;;;;;;;;;;;568:25;;;;;;;;;;;;;;;;;535:21;;568:25;;575:18;;568:25;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;473:127;;;:::o;237:230::-;340:10;322:15;361:18;;;;;;;;;;:37;;;;;;;;;;;;385:12;;361:37;;;;385:12;361:37;2205:5:17;2192:19;2186:4;2179:33;2266:2;2259:5;2255:14;2242:28;2238:1;2232:4;2228:12;2221:50;2325:2;2318:5;2314:14;2301:28;2297:1;2291:4;2287:12;2280:50;;;2030:306;361:37:16;-1:-1:-1;;414:46:16;;;430:17;;2515:25:17;;449:10:16;2571:2:17;2556:18;;2549:60;414:46:16;;2488:18:17;414:46:16;;;;;;;312:155;237:230;:::o;14:173:17:-;82:20;;-1:-1:-1;;;;;131:31:17;;121:42;;111:70;;177:1;174;167:12;111:70;14:173;;;:::o;192:254::-;260:6;268;321:2;309:9;300:7;296:23;292:32;289:52;;;337:1;334;327:12;289:52;360:29;379:9;360:29;:::i;:::-;350:39;436:2;421:18;;;;408:32;;-1:-1:-1;;;192:254:17:o;775:186::-;834:6;887:2;875:9;866:7;862:23;858:32;855:52;;;903:1;900;893:12;855:52;926:29;945:9;926:29;:::i;:::-;916:39;775:186;-1:-1:-1;;;775:186:17:o;966:855::-;1199:2;1251:21;;;1321:13;;1224:18;;;1343:22;;;1170:4;;1199:2;1384;;1402:18;;;;1443:15;;;1170:4;1486:309;1500:6;1497:1;1494:13;1486:309;;;1559:13;;1597:9;;1585:22;;1647:11;;;1641:18;1627:12;;;1620:40;1700:11;;1694:18;1680:12;;;1673:40;1742:4;1733:14;;;;1770:15;;;;1522:1;1515:9;1486:309;;;-1:-1:-1;1812:3:17;;966:855;-1:-1:-1;;;;;;;966:855:17:o;1826:199::-;1918:6;1971:2;1959:9;1950:7;1946:23;1942:32;1939:52;;;1987:1;1984;1977:12;1939:52;-1:-1:-1;2010:9:17;1826:199;-1:-1:-1;1826:199:17:o",
-    "linkReferences": {}
-  },
-  "methodIdentifiers": {
-    "addTraining((bytes32,bytes32,uint256))": "f1e823e2",
-    "getTrainings(address)": "77f6c91e",
-    "trainings(address,uint256)": "5898d018"
-  },
-  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.25+commit.b61c2a91\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"bytes32\",\"name\":\"name\",\"type\":\"bytes32\"},{\"indexed\":false,\"internalType\":\"address\",\"name\":\"creator\",\"type\":\"address\"}],\"name\":\"TrainingCreated\",\"type\":\"event\"},{\"inputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"name\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"description\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"durationInMinutes\",\"type\":\"uint256\"}],\"internalType\":\"struct ITrainingsManager.TrainingInfo\",\"name\":\"trainingInfo\",\"type\":\"tuple\"}],\"name\":\"addTraining\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"creator\",\"type\":\"address\"}],\"name\":\"getTrainings\",\"outputs\":[{\"components\":[{\"internalType\":\"bytes32\",\"name\":\"name\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"description\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"durationInMinutes\",\"type\":\"uint256\"}],\"internalType\":\"struct ITrainingsManager.TrainingInfo[]\",\"name\":\"\",\"type\":\"tuple[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"trainings\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"name\",\"type\":\"bytes32\"},{\"internalType\":\"bytes32\",\"name\":\"description\",\"type\":\"bytes32\"},{\"internalType\":\"uint256\",\"name\":\"durationInMinutes\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"kind\":\"dev\",\"methods\":{},\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{},\"version\":1}},\"settings\":{\"compilationTarget\":{\"src/trainings/TrainingsManager.sol\":\"TrainingsManager\"},\"evmVersion\":\"cancun\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":200},\"remappings\":[\":forge-std/=lib/forge-std/src/\"]},\"sources\":{\"src/trainings/ITrainingsManager.sol\":{\"keccak256\":\"0xf2daf2afd8605df9a9f78326020dc92d42c31290f5edb8d91780e417f0aa97d1\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://8919bb4dd496c284d9f3b29940a108c20742dac0f6bdd7141c3be971740c4696\",\"dweb:/ipfs/QmWrgkunPYYBwiCfLerbq39f7LbroUnNRCAqU6uzqGNHe8\"]},\"src/trainings/TrainingsManager.sol\":{\"keccak256\":\"0x4e73c4ee7fda9e758a21e6c023f3ec4890ad7e3376e65575a810c70a30997528\",\"license\":\"UNLICENSED\",\"urls\":[\"bzz-raw://fb7860f6cba6d07f8d067c251411b59ddd24a1b327272c89119daf74d77ded72\",\"dweb:/ipfs/QmQwj6WxiHj6pvvNrbm9vtY3NPySZ8QF8AhTyptkcFD8Wr\"]}},\"version\":1}",
-  "metadata": {
-    "compiler": {
-      "version": "0.8.25+commit.b61c2a91"
     },
-    "language": "Solidity",
-    "output": {
-      "abi": [
+    {
+      "type": "event",
+      "name": "TrainingDeleted",
+      "inputs": [
         {
-          "inputs": [
-            {
-              "internalType": "bytes32",
-              "name": "name",
-              "type": "bytes32",
-              "indexed": false
-            },
-            {
-              "internalType": "address",
-              "name": "creator",
-              "type": "address",
-              "indexed": false
-            }
-          ],
-          "type": "event",
-          "name": "TrainingCreated",
-          "anonymous": false
+          "name": "name",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
         },
         {
-          "inputs": [
-            {
-              "internalType": "struct ITrainingsManager.TrainingInfo",
-              "name": "trainingInfo",
-              "type": "tuple",
-              "components": [
-                {
-                  "internalType": "bytes32",
-                  "name": "name",
-                  "type": "bytes32"
-                },
-                {
-                  "internalType": "bytes32",
-                  "name": "description",
-                  "type": "bytes32"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "durationInMinutes",
-                  "type": "uint256"
-                }
-              ]
-            }
-          ],
-          "stateMutability": "nonpayable",
-          "type": "function",
-          "name": "addTraining"
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "creator",
-              "type": "address"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function",
-          "name": "getTrainings",
-          "outputs": [
-            {
-              "internalType": "struct ITrainingsManager.TrainingInfo[]",
-              "name": "",
-              "type": "tuple[]",
-              "components": [
-                {
-                  "internalType": "bytes32",
-                  "name": "name",
-                  "type": "bytes32"
-                },
-                {
-                  "internalType": "bytes32",
-                  "name": "description",
-                  "type": "bytes32"
-                },
-                {
-                  "internalType": "uint256",
-                  "name": "durationInMinutes",
-                  "type": "uint256"
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "inputs": [
-            {
-              "internalType": "address",
-              "name": "",
-              "type": "address"
-            },
-            {
-              "internalType": "uint256",
-              "name": "",
-              "type": "uint256"
-            }
-          ],
-          "stateMutability": "view",
-          "type": "function",
-          "name": "trainings",
-          "outputs": [
-            {
-              "internalType": "bytes32",
-              "name": "name",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "bytes32",
-              "name": "description",
-              "type": "bytes32"
-            },
-            {
-              "internalType": "uint256",
-              "name": "durationInMinutes",
-              "type": "uint256"
-            }
-          ]
+          "name": "creator",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
         }
       ],
-      "devdoc": {
-        "kind": "dev",
-        "methods": {},
-        "version": 1
-      },
-      "userdoc": {
-        "kind": "user",
-        "methods": {},
-        "version": 1
-      }
-    },
-    "settings": {
-      "remappings": [
-        "forge-std/=lib/forge-std/src/"
-      ],
-      "optimizer": {
-        "enabled": true,
-        "runs": 200
-      },
-      "metadata": {
-        "bytecodeHash": "ipfs"
-      },
-      "compilationTarget": {
-        "src/trainings/TrainingsManager.sol": "TrainingsManager"
-      },
-      "evmVersion": "cancun",
-      "libraries": {}
-    },
-    "sources": {
-      "src/trainings/ITrainingsManager.sol": {
-        "keccak256": "0xf2daf2afd8605df9a9f78326020dc92d42c31290f5edb8d91780e417f0aa97d1",
-        "urls": [
-          "bzz-raw://8919bb4dd496c284d9f3b29940a108c20742dac0f6bdd7141c3be971740c4696",
-          "dweb:/ipfs/QmWrgkunPYYBwiCfLerbq39f7LbroUnNRCAqU6uzqGNHe8"
-        ],
-        "license": "UNLICENSED"
-      },
-      "src/trainings/TrainingsManager.sol": {
-        "keccak256": "0x4e73c4ee7fda9e758a21e6c023f3ec4890ad7e3376e65575a810c70a30997528",
-        "urls": [
-          "bzz-raw://fb7860f6cba6d07f8d067c251411b59ddd24a1b327272c89119daf74d77ded72",
-          "dweb:/ipfs/QmQwj6WxiHj6pvvNrbm9vtY3NPySZ8QF8AhTyptkcFD8Wr"
-        ],
-        "license": "UNLICENSED"
-      }
-    },
-    "version": 1
-  },
-  "id": 16
+      "anonymous": false
+    }
+  ]
 }

--- a/dtrainings-ui/src/hooks/contracts/abi/TrainingsManager.json
+++ b/dtrainings-ui/src/hooks/contracts/abi/TrainingsManager.json
@@ -23,6 +23,11 @@
               "name": "durationInMinutes",
               "type": "uint256",
               "internalType": "uint256"
+            },
+            {
+              "name": "createdAt",
+              "type": "uint256",
+              "internalType": "uint256"
             }
           ]
         }
@@ -42,6 +47,25 @@
       ],
       "outputs": [],
       "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "getTrainingCount",
+      "inputs": [
+        {
+          "name": "creator",
+          "type": "address",
+          "internalType": "address"
+        }
+      ],
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "stateMutability": "view"
     },
     {
       "type": "function",
@@ -73,6 +97,11 @@
               "name": "durationInMinutes",
               "type": "uint256",
               "internalType": "uint256"
+            },
+            {
+              "name": "createdAt",
+              "type": "uint256",
+              "internalType": "uint256"
             }
           ]
         }
@@ -85,6 +114,42 @@
       "inputs": [],
       "outputs": [],
       "stateMutability": "nonpayable"
+    },
+    {
+      "type": "function",
+      "name": "updateTraining",
+      "inputs": [
+        {
+          "name": "name",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newDescription",
+          "type": "bytes32",
+          "internalType": "bytes32"
+        },
+        {
+          "name": "newDurationInMinutes",
+          "type": "uint256",
+          "internalType": "uint256"
+        }
+      ],
+      "outputs": [],
+      "stateMutability": "nonpayable"
+    },
+    {
+      "type": "event",
+      "name": "Initialized",
+      "inputs": [
+        {
+          "name": "owner",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
     },
     {
       "type": "event",
@@ -108,6 +173,25 @@
     {
       "type": "event",
       "name": "TrainingDeleted",
+      "inputs": [
+        {
+          "name": "name",
+          "type": "bytes32",
+          "indexed": false,
+          "internalType": "bytes32"
+        },
+        {
+          "name": "creator",
+          "type": "address",
+          "indexed": false,
+          "internalType": "address"
+        }
+      ],
+      "anonymous": false
+    },
+    {
+      "type": "event",
+      "name": "TrainingUpdated",
       "inputs": [
         {
           "name": "name",

--- a/dtrainings-ui/src/hooks/mutations/useAddTraining.ts
+++ b/dtrainings-ui/src/hooks/mutations/useAddTraining.ts
@@ -3,7 +3,7 @@ import { useWalletClient } from "wagmi";
 import { Hash } from "viem";
 import addTrainingContract from "hooks/contracts/trainingsManager";
 import { stringToBytes32 } from "utils/converter";
-import { TrainingInfo } from "interfaces/trainings";
+import { TrainingCreateInput } from "interfaces/trainings";
 
 
 interface MutationResponse {
@@ -12,15 +12,16 @@ interface MutationResponse {
 }
 
 
-const useAddTraining = (options?: UseMutationOptions<MutationResponse, unknown, TrainingInfo>): UseMutationResult<MutationResponse, unknown, TrainingInfo> => {
+const useAddTraining = (options?: UseMutationOptions<MutationResponse, unknown, TrainingCreateInput>): UseMutationResult<MutationResponse, unknown, TrainingCreateInput> => {
     const { data: walletClient } = useWalletClient();
 
     return useMutation({
-        mutationFn: async ({ name, description, durationInMinutes }: TrainingInfo) => {
+        mutationFn: async ({ name, description, durationInMinutes }: TrainingCreateInput) => {
             const trainingInfo = {
                 name: stringToBytes32(name),
                 description: stringToBytes32(description),
-                durationInMinutes: BigInt(durationInMinutes)
+                durationInMinutes: BigInt(durationInMinutes),
+                createdAt: BigInt(0)
             }
 
             return addTrainingContract({

--- a/dtrainings-ui/src/hooks/mutations/useDeleteTraining.ts
+++ b/dtrainings-ui/src/hooks/mutations/useDeleteTraining.ts
@@ -1,0 +1,35 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { useWalletClient } from "wagmi";
+import { Hash } from "viem";
+import addTrainingContract from "hooks/contracts/trainingsManager";
+import { stringToBytes32 } from "utils/converter";
+
+
+interface MutationResponse {
+    hash: Hash;
+}
+
+
+const useDeleteTraining = (options?: UseMutationOptions<MutationResponse, unknown, string>): UseMutationResult<MutationResponse, unknown, string> => {
+    const { data: walletClient } = useWalletClient();
+
+    return useMutation({
+        mutationFn: async (name: string) => {
+            const bytes32Name = stringToBytes32(name);
+
+            return addTrainingContract({
+                walletClient: walletClient!,
+                functionName: 'deleteTraining',
+                args: [bytes32Name]
+            }).then((data: any) => ({
+                hash: data,
+            })).catch((error: any) => {
+                console.log("ERROR", error);
+                throw error;
+            });
+        },
+        ...options,
+    });
+};
+
+export default useDeleteTraining;

--- a/dtrainings-ui/src/hooks/mutations/useUpdateTraining.ts
+++ b/dtrainings-ui/src/hooks/mutations/useUpdateTraining.ts
@@ -1,0 +1,37 @@
+import { useMutation, UseMutationOptions, UseMutationResult } from '@tanstack/react-query';
+import { useWalletClient } from "wagmi";
+import { Hash } from "viem";
+import addTrainingContract from "hooks/contracts/trainingsManager";
+import { stringToBytes32 } from "utils/converter";
+import { TrainingUpdateInput } from "interfaces/trainings";
+
+
+interface MutationResponse {
+    hash: Hash;
+}
+
+
+const useUpdateTraining = (options?: UseMutationOptions<MutationResponse, unknown, TrainingUpdateInput>): UseMutationResult<MutationResponse, unknown, TrainingUpdateInput> => {
+    const { data: walletClient } = useWalletClient();
+
+    return useMutation({
+        mutationFn: async ({ name, newDescription, newDurationInMinutes }: TrainingUpdateInput) => {
+            const bytes32Name = stringToBytes32(name);
+            const bytes32Desc = stringToBytes32(newDescription);
+
+            return addTrainingContract({
+                walletClient: walletClient!,
+                functionName: 'updateTraining',
+                args: [bytes32Name, bytes32Desc, BigInt(newDurationInMinutes)]
+            }).then((data: any) => ({
+                hash: data,
+            })).catch((error: any) => {
+                console.log("ERROR", error);
+                throw error;
+            });
+        },
+        ...options,
+    });
+};
+
+export default useUpdateTraining;

--- a/dtrainings-ui/src/hooks/queries/useGetTrainings.ts
+++ b/dtrainings-ui/src/hooks/queries/useGetTrainings.ts
@@ -18,9 +18,10 @@ export const useGetTrainingsForUser = (args: unknown[]) => {
         queryKey: ['getTrainings'],
         select: (response) =>
             response.map(training => ({
-                ...training,
                 name: bytes32ToString(training.name),
                 description: bytes32ToString(training.description),
+                durationInMinutes: training.durationInMinutes,
+                createdAt: training.createdAt,
             })),
     });
 }

--- a/dtrainings-ui/src/interfaces/trainings.tsx
+++ b/dtrainings-ui/src/interfaces/trainings.tsx
@@ -2,4 +2,17 @@ export interface TrainingInfo {
     name: string;
     description: string;
     durationInMinutes: bigint;
+    createdAt: bigint;
+}
+
+export interface TrainingCreateInput {
+    name: string;
+    description: string;
+    durationInMinutes: bigint;
+}
+
+export interface TrainingUpdateInput {
+    name: string;
+    newDescription: string;
+    newDurationInMinutes: bigint;
 }


### PR DESCRIPTION
## Summary

- **Delete Training**: Updated contract ABI with `deleteTraining(bytes32)` + `TrainingDeleted` event, added `useDeleteTraining` mutation hook, and wired it through a confirmation dialog in TrainingsManager
- **Stats Page**: New `/stats` route with computed metrics (total trainings, total time, average duration, longest training) and recent trainings list, reusing `useGetTrainingsForUser`
- **Search/Filter**: Added search bar to TrainingsManager that filters trainings by name (case-insensitive)
- **Network Guard**: New `NetworkGuard` component that detects wrong chain and prompts user to switch via `useSwitchChain()`. Applied to TrainingsManager and Stats pages
- **Navigation**: Added Stats link to Navbar, unlocked "Your Stats" card on Home page

## Test plan

- [ ] Verify `/trainings-manager` loads without errors
- [ ] Search bar filters trainings by name
- [ ] Click "Delete" on a training → confirmation dialog appears → confirm triggers transaction + toast feedback
- [ ] Navigate to `/stats` → 4 stat cards render with correct computed values
- [ ] Empty state shown on Stats when no trainings exist
- [ ] Switch wallet to wrong chain → NetworkGuard overlay with "Switch to Sepolia" button
- [ ] Home page "Your Stats" card is clickable and navigates to `/stats`
- [ ] Navbar "Stats" link is visible and active on `/stats`
- [ ] `npm run build` compiles without errors

> **Note:** `deleteTraining` will revert onchain until the proxy contract on Sepolia is upgraded to the new implementation.